### PR TITLE
Migrate to ECS environment

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -1,0 +1,59 @@
+name: build container image when branches are pushed
+
+on:
+  push:
+    branches: ["*"]
+
+jobs:
+  build:
+    if: github.event.pusher.name != 'dreamkast-cloudnativedays'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ steps.login-ecr.outputs.registry }}/seaman
+          tags: |
+            type=sha,prefix=,format=long
+            type=ref,event=branch
+
+      - id: get-tag
+        run: |
+          if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
+            echo "::set-output name=tag::$(echo ${{ github.ref }} | sed -e 's|^refs/tags/\(.*\)$|\1|g')"
+          else
+            echo "::set-output name=tag::none"
+          fi
+
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.get-tag.outputs.tag }}
+            APP_COMMIT=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -1,10 +1,11 @@
-name: build container image
+name: build container image when tags are pushed
 
-on: push
+on:
+  push:
+    tags: ["*"]
 
 jobs:
   build:
-    if: github.event.pusher.name != 'dreamkast-cloudnativedays'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,23 +19,20 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1 # because of using public registry
+          aws-region: ap-northeast-1
 
-      - name: Login to Amazon ECR Public
-        id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          registry-type: public
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: public.ecr.aws/f5j9d0q5/seaman
+          images: ${{ steps.login-ecr.outputs.registry }}/seaman
           tags: |
             type=sha,prefix=,format=long
             type=ref,event=branch
-            type=semver,pattern={{version}}
 
       - id: get-tag
         run: |


### PR DESCRIPTION
* ECS 移行に伴い GitHub Actions からの push 先 ECR repository を更新
    * ~~dev, stage (us-west-2): ECS から us-west-2 の ECR private repo へ VPC Endpoint 越しに image pull~~
        * seaman は prod でのみ動作予定
    * prod (ap-northeast-1): ECS から ap-northeast-1 の ECR private repo へ VPC Endpoint 越しに image pull
* TODO: ECS 移行に伴う gitops Action の更新